### PR TITLE
[Book] add tooling to produce a .docx book

### DIFF
--- a/book.yaml
+++ b/book.yaml
@@ -1,0 +1,18 @@
+from: markdown+lists_without_preceding_blankline+rebase_relative_paths
+to: docx
+reference-doc: hsbi.docx
+
+metadata-file: metadata.yaml
+
+citeproc: true
+metadata:
+  csl: https://www.zotero.org/styles/springer-lecture-notes-in-computer-science
+  link-citations: true
+
+strip-comments: true
+standalone: true
+wrap: preserve
+
+
+filters:
+- prepareHandout.lua


### PR DESCRIPTION
Die HSBI hat neue Dokumentvorlagen, mit denen offizielle (und halboffizielle Dokumente wie diese FAQ) produziert werden sollen. Unglücklicherweise sind dies lediglich Word-Vorlagen, die zudem nicht unter einer OER-Lizenz stehen. 

Dieser PR fügt ein neues Target `book` im Makefile hinzu, welches die FAQ in ein Buch im .docx-Format kompiliert. Dazu wird als Template eine Worddatei benötigt, die nicht in dieses Repo hochgeladen werden kann. Aus diesem Grund muss das Buch lokal produziert werden, und es gibt entsprechend auch keinen GitHub-Workflow.