### PR TITLE
[Tool]: switch to H1 based document workflow

### DIFF
--- a/.license_slide.md
+++ b/.license_slide.md
@@ -1,6 +1,6 @@
 ::::::::: notes
 ::: {#refs}
-# Quellen und Links {.unnumbered}
+## Quellen und Links {.unnumbered}
 :::
 :::::::::
 

--- a/.pandoc/book.yaml
+++ b/.pandoc/book.yaml
@@ -11,7 +11,6 @@ metadata:
 
 strip-comments: true
 wrap: preserve
-shift-heading-level-by: +1
 
 filters:
   - prepareHandout.lua

--- a/.pandoc/gfm.yaml
+++ b/.pandoc/gfm.yaml
@@ -12,6 +12,7 @@ metadata:
 standalone: true
 strip-comments: true
 wrap: preserve
+
 toc: true
 toc-depth: 2
 

--- a/.pandoc/gfm.yaml
+++ b/.pandoc/gfm.yaml
@@ -9,13 +9,12 @@ metadata:
   #cls: https://www.zotero.org/styles/springer-basic-author-date
   link-citations: true
 
+standalone: true
 strip-comments: true
 wrap: preserve
 toc: true
-standalone: true
-shift-heading-level-by: +1
+toc-depth: 2
 
 filters:
-  - title2h1.lua
   - prepareHandout.lua
   - removeMetadata.lua

--- a/.pandoc/slides.yaml
+++ b/.pandoc/slides.yaml
@@ -12,7 +12,8 @@ metadata:
 
 strip-comments: true
 wrap: preserve
-slide-level: 2
+
+shift-heading-level-by: -1
 
 pdf-engine: pdflatex
 pdf-engine-opt: '-shell-escape'

--- a/.pandoc/slides.yaml
+++ b/.pandoc/slides.yaml
@@ -25,9 +25,5 @@ variables:
     - numbering=none
     - progressbar=foot
 
-include-in-header:
-  - resources/definitions.tex
-
 filters:
   - prepareSlides.lua
-  - tex.lua

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ PANDOC           = pandoc
 ##     (b) If we are running locally (native installation), we look for the
 ##         files at ${HOME}/.local/share/pandoc/.
 ## XDG_DATA_HOME can be set externally
-XDG_DATA_HOME ?= $(HOME)/.local/share
-PANDOC_DIRS = --resource-path=".:$(XDG_DATA_HOME)/pandoc/:$(XDG_DATA_HOME)/pandoc/resources/"
+XDG_DATA_HOME   ?= $(HOME)/.local/share
+PANDOC_DIRS      = --resource-path=".:$(XDG_DATA_HOME)/pandoc/:$(XDG_DATA_HOME)/pandoc/resources/"
 
 
 #--------------------------------------------------------------------------------
@@ -42,7 +42,6 @@ PANDOC_DIRS = --resource-path=".:$(XDG_DATA_HOME)/pandoc/:$(XDG_DATA_HOME)/pando
 MARKDOWN_SOURCES = README.md faq_praxisphase.md faq_abschlussarbeit.md faq_nachteilsausgleich.md
 GFM_IMAGES		 = $(shell find $(IMG_DIR) -type f -iname '*.png')
 LICENSE_SLIDE    = .license_slide.md
-INTERN_TEMPLATE  = $(PANDOC_CONF)/hsbi.docx
 IMG_DIR          = img
 OUTPUT_DIR       = docs
 PANDOC_CONF      = .pandoc
@@ -51,7 +50,6 @@ SLIDES_TARGETS   = $(MARKDOWN_SOURCES:%.md=$(OUTPUT_DIR)/%.pdf)
 GFM_TARGETS      = $(MARKDOWN_SOURCES:%.md=$(OUTPUT_DIR)/%.md)
 GFM_IMG_TARGETS  = $(GFM_IMAGES:$(IMG_DIR)/%.png=$(OUTPUT_DIR)/$(IMG_DIR)/%.png)
 BOOK_Target      = $(OUTPUT_DIR)/IFM_FAQ_Praxisphase_Bachelorarbeit.docx
-BOOK_TMP_FILES   = $(MARKDOWN_SOURCES:%.md=__%.md)
 
 
 #--------------------------------------------------------------------------------
@@ -81,13 +79,9 @@ gfm: $(OUTPUT_DIR) $(OUTPUT_DIR)/$(IMG_DIR) $(GFM_TARGETS) $(GFM_IMG_TARGETS) ##
 .PHONY: book
 book: $(OUTPUT_DIR) $(BOOK_Target) ## Create a book
 
-.PHONY: book_internal
-book_internal: $(OUTPUT_DIR) $(INTERN_TEMPLATE) $(BOOK_Target) ## Create a book (needs internal template!)
-
 
 .PHONY: clean
 clean: ## Clean up intermediate files
-	rm -rf $(BOOK_TMP_FILES)
 
 .PHONY: distclean
 distclean: clean ## Clean up intermediate files and generated artifacts
@@ -112,8 +106,5 @@ $(GFM_TARGETS): $(OUTPUT_DIR)/%.md: %.md $(LICENSE_SLIDE)
 $(GFM_IMG_TARGETS): $(OUTPUT_DIR)/$(IMG_DIR)/%.png: $(IMG_DIR)/%.png
 	cp $^ $@
 
-$(BOOK_Target): $(BOOK_TMP_FILES) $(LICENSE_SLIDE)
+$(BOOK_Target): $(MARKDOWN_SOURCES) $(LICENSE_SLIDE)
 	$(PANDOC) $(PANDOC_DIRS) -d $(PANDOC_CONF)/book   $^ -o $@
-
-$(BOOK_TMP_FILES): __%.md: %.md
-	$(PANDOC) $(PANDOC_DIRS) -L title2h1.lua -s $< -o $@

--- a/faq_abschlussarbeit.md
+++ b/faq_abschlussarbeit.md
@@ -17,20 +17,17 @@ Die Bachelorarbeit wird in der Prüfungsordnung geregelt:
     -   Modulbeschreibung zum Modul "Bachelorarbeit"
 :::
 
-#### Ziel
-
-Selbstständige Bearbeitung einer praxisorientierten Aufgabe im Fachgebiet mit wissenschaftlichen
-Methoden innerhalb einer vorgegebenen Frist
+**Ziel**: Selbstständige Bearbeitung einer praxisorientierten Aufgabe im Fachgebiet mit
+wissenschaftlichen Methoden innerhalb einer vorgegebenen Frist
 
 \bigskip
+\smallskip
 
-#### Umfang
-
-3 Monate [(12 Wochen)]{.notes} mit 12 ECTS Arbeitsaufwand (Vollzeit, ohne Unterbrechung: 360h)
+**Umfang**: 3 Monate [(12 Wochen)]{.notes} mit 12 ECTS Arbeitsaufwand (Vollzeit, ohne Unterbrechung: 360h)
 
 ### Wo kann ich meine Bachelorarbeit durchführen?
 
-#### Extern: Firma
+**Extern**: Firma
 
 ::: notes
 Häufig wird die Bachelorarbeit in einer Firma durchgeführt.
@@ -38,15 +35,16 @@ Häufig wird die Bachelorarbeit in einer Firma durchgeführt.
 Dazu wird in der Regel ein Vertrag zwischen Ihnen und der Firma abgeschlossen, in dem auch die
 Vertragslaufzeit, wöchentliche Arbeitszeit und das Entgeld geregelt werden.
 
-**Hinweis:** Dieser Vertrag ist Ihre Privatangelegenheit und hat nichts mit der Prüfungsleistung
+_Anmerkung_: Dieser Vertrag ist Ihre Privatangelegenheit und hat nichts mit der Prüfungsleistung
 "Bachelorarbeit" an der HSBI zu tun. Im Extremfall kann sich beispielsweise die Vertragslaufzeit
 deutlich von der Bearbeitungszeit der Bachelorarbeit (Zeitraum zwischen Anmeldung/Genehmigung und
 Beendigung) unterscheiden!
 :::
 
 \bigskip
+\smallskip
 
-#### Intern: Labor oder Forschungsprojekt
+**Intern**: Labor oder Forschungsprojekt
 
 ::: notes
 Sie können je nach Angebot die Bachelorarbeit aber auch in der Hochschule in einem Labor oder einem

--- a/faq_abschlussarbeit.md
+++ b/faq_abschlussarbeit.md
@@ -1,10 +1,8 @@
----
-title: "FAQ: Abschlussarbeit"
----
+# FAQ: Abschlussarbeit
 
-# Überblick und Einordnung
+## Überblick und Einordnung
 
-## Worum geht es in der Bachelorarbeit?
+### Worum geht es in der Bachelorarbeit?
 
 ::: notes
 Die Bachelorarbeit wird in der Prüfungsordnung geregelt:
@@ -19,20 +17,20 @@ Die Bachelorarbeit wird in der Prüfungsordnung geregelt:
     -   Modulbeschreibung zum Modul "Bachelorarbeit"
 :::
 
-### Ziel
+#### Ziel
 
 Selbstständige Bearbeitung einer praxisorientierten Aufgabe im Fachgebiet mit wissenschaftlichen
 Methoden innerhalb einer vorgegebenen Frist
 
 \bigskip
 
-### Umfang
+#### Umfang
 
 3 Monate [(12 Wochen)]{.notes} mit 12 ECTS Arbeitsaufwand (Vollzeit, ohne Unterbrechung: 360h)
 
-## Wo kann ich meine Bachelorarbeit durchführen?
+### Wo kann ich meine Bachelorarbeit durchführen?
 
-### Extern: Firma
+#### Extern: Firma
 
 ::: notes
 Häufig wird die Bachelorarbeit in einer Firma durchgeführt.
@@ -48,7 +46,7 @@ Beendigung) unterscheiden!
 
 \bigskip
 
-### Intern: Labor oder Forschungsprojekt
+#### Intern: Labor oder Forschungsprojekt
 
 ::: notes
 Sie können je nach Angebot die Bachelorarbeit aber auch in der Hochschule in einem Labor oder einem
@@ -58,7 +56,7 @@ Häufig absolvieren Sie hier lediglich die Prüfungsleistung, d.h. Sie werden ni
 Forschungsprojekt eingestellt.
 :::
 
-## Betreuer:innen und Prüfer:innen
+### Betreuer:innen und Prüfer:innen
 
 -   Erstprüfer:in: Dozent:in im Studiengang (HSBI)
 -   Zweitprüfer:in:
@@ -75,9 +73,9 @@ Antrag auf Zulassung zur Bachelorarbeit [@AntragBA] angeben und unterschreiben l
 In der Regel sind die Prüfer:innen auch gleichzeitig die Betreuer:innen.
 :::
 
-# Vorbereitung
+## Vorbereitung
 
-## Wie finde ich ein Thema und Betreuer:innen?
+### Wie finde ich ein Thema und Betreuer:innen?
 
 -   **Nutzen Sie die Praxisphase: Kontakt in der jeweiligen Firma!**
 
@@ -89,7 +87,7 @@ In der Regel sind die Prüfer:innen auch gleichzeitig die Betreuer:innen.
 -   Mint-Mentoring [[@MintMentoring] ([Details siehe Folie zum Mint-Mentoring](faq_praxisphase.md#detailsmint))]{.notes}
 -   Stellenanzeigen (Internet, Zeitungen, HSBI-Stellenportal[ [@Stellenportal]]{.notes}, Schwarze Bretter)
 
-## Wie starte ich in meine Bachelorarbeit?
+### Wie starte ich in meine Bachelorarbeit?
 
 ![Zeitlicher Ablauf Bachelorarbeit](img/screenshot_prozess_bachelorarbeit.png){width="80%"}
 
@@ -132,7 +130,7 @@ In der Regel sind die Prüfer:innen auch gleichzeitig die Betreuer:innen.
 :::
 
 ::: notes
-## Voraussetzungen für die Anmeldung der Bachelorarbeit
+### Voraussetzungen für die Anmeldung der Bachelorarbeit
 
 -   Sie haben die Modulprüfungen bis auf vier bestanden [vgl. @SPO-BA18{}, §10 (1)]
 -   Sie haben eine Person aus dem Kreis der Dozent:innen im Studiengang gefunden, die bereit ist,
@@ -147,7 +145,7 @@ In der Regel sind die Prüfer:innen auch gleichzeitig die Betreuer:innen.
 :::
 
 ::: notes
-## Bemerkungen zum Start der Bachelorarbeit
+### Bemerkungen zum Start der Bachelorarbeit
 
 -   Bearbeitungszeitraum der Bachelorarbeit nicht an Vorlesungszeiten gebunden
 -   Beachten Sie die Fortschrittsregelung [[vgl. @SPO-BA18{} §24; @SPO-BA23{} §23]]{.notes}
@@ -158,16 +156,16 @@ In der Regel sind die Prüfer:innen auch gleichzeitig die Betreuer:innen.
     Abgabefrist für den Praxisphasenbericht beantragen und beginnen.)]{.notes}
 :::
 
-# Während der Arbeit
+## Während der Arbeit
 
-## Welche Termine gibt es während der Bearbeitungszeit?
+### Welche Termine gibt es während der Bearbeitungszeit?
 
 Das ist abhängig von Ihren Betreuer:innen. Besprechen Sie dies rechtzeitig mit beiden Prüfer:innen!
 
 **Hinweis**: Es bietet sich an, regelmäßig den Kontakt zu beiden Prüfer:innen zu suchen und sie über
 den Stand der Arbeiten zu informieren!
 
-## Aufbau der Arbeit? Gibt es eine Vorlage?
+### Aufbau der Arbeit? Gibt es eine Vorlage?
 
 -   Anforderungen gemäß Studiengangsprüfungsordnung: Seitenumfang 30 bis 80 Seiten
     [[@SPO-BA18{} §23 (2); @SPO-BA23{} §22 (2)]]{.notes}
@@ -217,9 +215,9 @@ den Stand der Arbeiten zu informieren!
 
 **Wichtig**: Besprechen Sie dies rechtzeitig mit den beiden Prüfer:innen!
 
-# Abgabe
+## Abgabe
 
-## Abgabe: Was muss ich hinterher einreichen?
+### Abgabe: Was muss ich hinterher einreichen?
 
 -   Formale Abgabe: Online über "Studium > Studium organisieren > Einreichung von schriftlichen Arbeiten" [[@EinreichungBA]]{.notes}
     -   Schriftliche Ausarbeitung (30 bis 80 Seiten) als PDF
@@ -248,7 +246,7 @@ In der neuen Prüfungsordnung findet sich nur noch die elektronische Abgabe
 [@SPO-BA23{}, §25].
 :::
 
-## Sperrvermerk und Source-Code
+### Sperrvermerk und Source-Code
 
 -   Sensible Unternehmensdaten: Sperrvermerk einfügen (Absprache mit der Firma!)
 
@@ -281,7 +279,7 @@ In der neuen Prüfungsordnung findet sich nur noch die elektronische Abgabe
     zugreifbares Repo.
     :::
 
-## Bekomme ich eine Note?
+### Bekomme ich eine Note?
 
 JA :-)
 
@@ -293,9 +291,9 @@ Wert überschreitet, wird noch eine dritte Prüfer:in hinzugezogen.
 Sprechen Sie rechtzeitig mit Ihren Betreuer:innen über mögliche individuelle Anforderungen.
 :::
 
-# Sonstige Hinweise
+## Sonstige Hinweise
 
-## Verlängerung der Bearbeitungszeit in Ausnahmefällen
+### Verlängerung der Bearbeitungszeit in Ausnahmefällen
 
 Antrag auf Fristverlängerung beim vorsitzenden Mitglied des Prüfungsausschusses stellen
 (Nachweise!) [[vgl. @RPO-BA{}, § 28 (3)]]{.notes}
@@ -311,7 +309,7 @@ Nutzen Sie dazu das Formular: Antrag auf Fristverlängerung [@VerlBA].
 Wichtig: Die angeführten Gründe müssen geeignet nachgewiesen werden!
 :::
 
-## Nachteilsausgleich
+### Nachteilsausgleich
 
 Bei Einschränkungen durch gesundheitliche Probleme oder Familienaufgaben können Sie einen
 Nachteilsausgleich beantragen

--- a/faq_nachteilsausgleich.md
+++ b/faq_nachteilsausgleich.md
@@ -1,6 +1,4 @@
----
-title: "FAQ: Nachteilsausgleich"
----
+# FAQ: Nachteilsausgleich
 
 ## Antrag auf Nachteilsausgleich
 

--- a/faq_praxisphase.md
+++ b/faq_praxisphase.md
@@ -1,6 +1,4 @@
----
-title: "FAQ: Praxisphase"
----
+# FAQ: Praxisphase
 
 ## Worum geht's in der Praxisphase?
 


### PR DESCRIPTION
Siehe #27:

H1 ist jetzt Dokument-Titel (es gibt genau ein H1 pro Dokument, muss am Anfang sein):

```markdown
# FAQ: Abschlussarbeit

## Worum geht es in der Bachelorarbeit?

Die Bachelorarbeit wird in der Prüfungsordnung geregelt:

-   RPO-BA:
    -   Kapitel "V. Bachelorarbeit"
-   SPO-BA23:
```

Die nötigen zusätzlichen Transformationen wurden in den Pandoc-Default-Files und im Makefile eingebaut:

- GFM: keine nötig
- DOCX: keine nötig (_Header für Quellen muss manuell angepasst werden_)
- BEAMER: `--shift-heading-level-by=-1`

---

fixes #27 
